### PR TITLE
fix issues installing for niri

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 just := just_executable()
 
-_build:
+build:
   {{ just }} cosmic-ext-alternative-startup/build-release
 
 _install rootdir="" prefix="/usr/local":

--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@ just := just_executable()
 _build:
   {{ just }} cosmic-ext-alternative-startup/build-release
 
-_install rootdir="" prefix="/usr/local": _build
+_install rootdir="" prefix="/usr/local":
   {{ just }} rootdir={{rootdir}} prefix={{prefix}} cosmic-ext-alternative-startup/install
 
 _build-sway:
@@ -16,8 +16,8 @@ install-sway rootdir="" prefix="/usr/local": _build-sway _install
   install -Dm0644 sway/start-cosmic-ext-sway {{rootdir}}{{prefix}}/bin/start-cosmic-ext-sway
 
 install-niri rootdir="" prefix="/usr/local": _install
-  sudo install -Dm0644 niri/cosmic-ext-niri.desktop {{rootdir}}{{prefix}}/share/wayland-sessions/cosmic-ext-niri.desktop
-  sudo install -Dm0755 niri/start-cosmic-ext-niri {{rootdir}}{{prefix}}/bin/start-cosmic-ext-niri
+  install -Dm0644 niri/cosmic-ext-niri.desktop {{rootdir}}{{prefix}}/share/wayland-sessions/cosmic-ext-niri.desktop
+  install -Dm0755 niri/start-cosmic-ext-niri {{rootdir}}{{prefix}}/bin/start-cosmic-ext-niri
 
 install-miracle rootdir="" prefix="/usr/local": _install
   install -Dm0644 miracle/cosmic-ext-miracle.desktop {{rootdir}}{{prefix}}/share/wayland-sessions/cosmic-ext-miracle.desktop

--- a/justfile
+++ b/justfile
@@ -9,15 +9,15 @@ _install rootdir="" prefix="/usr/local": _build
 _build-sway:
   {{ just }} sway/cosmic-ext-sway-daemon/build-release
 
-install-sway rootdir="" prefix="/usr/local": build-sway _install
+install-sway rootdir="" prefix="/usr/local": _build-sway _install
   {{ just }} rootdir={{rootdir}} prefix={{prefix}} sway/cosmic-ext-sway-daemon/install
   install -Dm0644 sway/config-cosmic {{rootdir}}/etc/sway/config-cosmic
   install -Dm0644 sway/cosmic-ext-sway.desktop {{rootdir}}{{prefix}}/share/wayland-sessions/cosmic-ext-sway.desktop
   install -Dm0644 sway/start-cosmic-ext-sway {{rootdir}}{{prefix}}/bin/start-cosmic-ext-sway
 
 install-niri rootdir="" prefix="/usr/local": _install
-  install -Dm0644 niri/cosmic-ext-niri.desktop {{rootdir}}{{prefix}}/share/wayland-sessions/cosmic-ext-niri.desktop
-  install -Dm0644 niri/start-cosmic-ext-niri {{rootdir}}{{prefix}}/bin/start-cosmic-ext-niri
+  sudo install -Dm0644 niri/cosmic-ext-niri.desktop {{rootdir}}{{prefix}}/share/wayland-sessions/cosmic-ext-niri.desktop
+  sudo install -Dm0755 niri/start-cosmic-ext-niri {{rootdir}}{{prefix}}/bin/start-cosmic-ext-niri
 
 install-miracle rootdir="" prefix="/usr/local": _install
   install -Dm0644 miracle/cosmic-ext-miracle.desktop {{rootdir}}{{prefix}}/share/wayland-sessions/cosmic-ext-miracle.desktop

--- a/niri/README.md
+++ b/niri/README.md
@@ -4,19 +4,51 @@ This is cosmic running on niri!
 
 ## Install
 
-Either clone the repo and run `just install-niri` or install manually:
+### Option 1 - Cloning the repo
+
+Clone the repo with:
+
+```bash
+git clone https://github.com/Drakulix/cosmic-ext-extra-sessions.git
+```
+
+Within the repo directory, install submodules:
+
+```bash
+cd cosmic-ext-extra-sessions
+git submodule update --init
+```
+
+And finally, instally for niri with:
+
+```bash
+just install-niri
+```
+
+### Option 2 - Manual installation
+
+Copy the following files:
+
 - `start-cosmic-ext-niri` somewhere in your `PATH`, e.g. /usr/local/bin
 - `cosmic-ext-niri.desktop` into `/usr/share/wayland-sessions/cosmic-ext-niri.desktop`
 
-Additionally you'll need to add this to your niri config:
+### Update your Niri config
+
+If you haven't yet, run niri once to generate a config file.
+
+In your niri `config.kdl file`, add the following line (removing any existing spawn-at-startup options):
+
 ```kdl
 spawn-at-startup "cosmic-ext-alternative-startup"
 ```
 
 I also recommend adding the following lines for the full cosmic experience to your `binds`:
+
 ```kdl
 Mod+T { spawn "cosmic-term"; }
 Mod+D { spawn "cosmic-launcher"; }
 Mod+Shift+D { spawn "cosmic-app-library"; }
 Mod+Alt+L { spawn "cosmic-greeter"; }
 ```
+
+Make sure to also disable any existing entries in your for these modifiers.

--- a/niri/README.md
+++ b/niri/README.md
@@ -19,10 +19,11 @@ cd cosmic-ext-extra-sessions
 git submodule update --init
 ```
 
-And finally, instally for niri with:
+And finally, build and install for niri with:
 
 ```bash
-just install-niri
+just _build
+sudo just install-niri
 ```
 
 ### Option 2 - Manual installation

--- a/niri/README.md
+++ b/niri/README.md
@@ -22,7 +22,7 @@ git submodule update --init
 And finally, build and install for niri with:
 
 ```bash
-just _build
+just build
 sudo just install-niri
 ```
 

--- a/niri/cosmic-ext-niri.desktop
+++ b/niri/cosmic-ext-niri.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=COSMIC on niri
 Comment=This session logs you into the COSMIC desktop on niri
-Exec=/usr/bin/start-cosmic-ext-niri
+Exec=/usr/local/bin/start-cosmic-ext-niri
 Type=Application
 DesktopNames=niri


### PR DESCRIPTION
This fixes a number of issues I had attempting to follow the installation instructions for niri, and improves the documentation around the process.

Note that while these changes enabled me to get a working session, I still can't see the Cosmic menu bar or dock in my session. I'm unclear however whether that's an issue with cosmic-ext-extra-sessions or with some component of Cosmic itself.