### PR TITLE
Make justfile more modular

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,24 +1,26 @@
 just := just_executable()
+rootdir := ''
+prefix := '/usr/local'
 
 build:
-  {{ just }} cosmic-ext-alternative-startup/build-release
+  {{ just }} rootdir={{rootdir}} prefix={{prefix}} cosmic-ext-alternative-startup/build-release
 
-_install rootdir="" prefix="/usr/local":
+install:
   {{ just }} rootdir={{rootdir}} prefix={{prefix}} cosmic-ext-alternative-startup/install
 
-_build-sway:
-  {{ just }} sway/cosmic-ext-sway-daemon/build-release
+build-sway:
+  {{ just }} rootdir={{rootdir}} prefix={{prefix}} sway/cosmic-ext-sway-daemon/build-release
 
-install-sway rootdir="" prefix="/usr/local": _build-sway _install
+install-sway:
   {{ just }} rootdir={{rootdir}} prefix={{prefix}} sway/cosmic-ext-sway-daemon/install
   install -Dm0644 sway/config-cosmic {{rootdir}}/etc/sway/config-cosmic
   install -Dm0644 sway/cosmic-ext-sway.desktop {{rootdir}}{{prefix}}/share/wayland-sessions/cosmic-ext-sway.desktop
-  install -Dm0644 sway/start-cosmic-ext-sway {{rootdir}}{{prefix}}/bin/start-cosmic-ext-sway
+  install -Dm0755 sway/start-cosmic-ext-sway {{rootdir}}{{prefix}}/bin/start-cosmic-ext-sway
 
-install-niri rootdir="" prefix="/usr/local": _install
+install-niri:
   install -Dm0644 niri/cosmic-ext-niri.desktop {{rootdir}}{{prefix}}/share/wayland-sessions/cosmic-ext-niri.desktop
   install -Dm0755 niri/start-cosmic-ext-niri {{rootdir}}{{prefix}}/bin/start-cosmic-ext-niri
 
-install-miracle rootdir="" prefix="/usr/local": _install
+install-miracle:
   install -Dm0644 miracle/cosmic-ext-miracle.desktop {{rootdir}}{{prefix}}/share/wayland-sessions/cosmic-ext-miracle.desktop
-  install -Dm0644 miracle/start-cosmic-ext-miracle {{rootdir}}{{prefix}}/bin/start-cosmic-ext-miracle
+  install -Dm0755 miracle/start-cosmic-ext-miracle {{rootdir}}{{prefix}}/bin/start-cosmic-ext-miracle

--- a/miracle/README.md
+++ b/miracle/README.md
@@ -4,11 +4,40 @@ This is cosmic running on miracle!
 
 ## Install
 
-Either clone the repo and run `just install-miracle` or install manually:
-- `start-cosmic-ext-miracle` somewhere in your `PATH`, e.g. /usr/local/bin
+### Option 1 - Cloning the repo
+
+Clone the repo with:
+
+```bash
+git clone https://github.com/Drakulix/cosmic-ext-extra-sessions.git
+```
+
+Within the repo directory, install submodules:
+
+```bash
+cd cosmic-ext-extra-sessions
+git submodule update --init
+```
+
+And finally, build and install for miracle with:
+
+```bash
+just build
+sudo just install
+sudo just install-miracle
+```
+
+### Option 2 - Manual installation
+
+Copy the following files:
+
+- `start-cosmic-ext-miracle` somewhere in your `PATH`, e.g. `/usr/local/bin`
 - `cosmic-ext-miracle.desktop` into `/usr/share/wayland-sessions/cosmic-ext-miracle.desktop`
 
+## Configuration
+
 Additionally you'll need to add this to your miracle config:
+
 ```
 startup_apps:
   - command: cosmic-alternative-startup

--- a/miracle/cosmic-ext-miracle.desktop
+++ b/miracle/cosmic-ext-miracle.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=COSMIC on miracle
 Comment=This session logs you into the COSMIC desktop on miracle
-Exec=/usr/bin/start-cosmic-ext-miracle
+Exec=/usr/local/bin/start-cosmic-ext-miracle
 Type=Application
 DesktopNames=miracle

--- a/niri/README.md
+++ b/niri/README.md
@@ -23,6 +23,7 @@ And finally, build and install for niri with:
 
 ```bash
 just build
+sudo just install
 sudo just install-niri
 ```
 
@@ -32,6 +33,8 @@ Copy the following files:
 
 - `start-cosmic-ext-niri` somewhere in your `PATH`, e.g. /usr/local/bin
 - `cosmic-ext-niri.desktop` into `/usr/share/wayland-sessions/cosmic-ext-niri.desktop`
+
+## Configuration
 
 ### Update your Niri config
 

--- a/sway/README.md
+++ b/sway/README.md
@@ -2,9 +2,34 @@
 
 This is cosmic running on sway!
 
-## Install
+### Option 1 - Cloning the repo
 
-Either clone the repo and run `just install-sway` or install manually:
+Clone the repo with:
+
+```bash
+git clone https://github.com/Drakulix/cosmic-ext-extra-sessions.git
+```
+
+Within the repo directory, install submodules:
+
+```bash
+cd cosmic-ext-extra-sessions
+git submodule update --init
+```
+
+And finally, build and install for sway with:
+
+```bash
+just build
+just build-sway
+sudo just install
+sudo just install-sway
+```
+
+### Option 2 - Manual installation
+
+Copy the following files:
+
 - `start-cosmic-ext-sway` somewhere in your `PATH`, e.g. `/usr/local/bin`
 - `cosmic-ext-sway.desktop` into `/usr/share/wayland-sessions/cosmic-ext-sway.desktop`
 - `config-cosmic` to `/etc/sway/config-cosmic`

--- a/sway/cosmic-ext-sway.desktop
+++ b/sway/cosmic-ext-sway.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=COSMIC on sway
 Comment=This session logs you into the COSMIC desktop on sway
-Exec=/usr/bin/start-cosmic-ext-sway
+Exec=/usr/local/bin/start-cosmic-ext-sway
 Type=Application
 DesktopNames=sway


### PR DESCRIPTION
This makes easier to install these sessions with Nix By making it possible to override prefix and rootdir And also making possible to not run `install` recipe since a separate package will be used for
cosmic-ext-alternative-setup