### PR TITLE
make niri use its own xdp instead of xdp-cosmic

### DIFF
--- a/niri/start-cosmic-ext-niri
+++ b/niri/start-cosmic-ext-niri
@@ -44,7 +44,7 @@ if command -v systemctl >/dev/null; then
 fi
 # Run cosmic-session
 if [[ -z "${DBUS_SESSION_BUS_ADDRESS}" ]]; then
-    exec /usr/bin/dbus-run-session -- /usr/bin/cosmic-session niri
+    exec /usr/bin/dbus-run-session -- /usr/bin/cosmic-session niri --session
 else
-    exec /usr/bin/cosmic-session niri
+    exec /usr/bin/cosmic-session niri --session
 fi


### PR DESCRIPTION
this will fix:
- obs-studio pipewire capture
- fcitx5 with GTK_IM_MODULE=wayland and QT_IM_MODULE=wayland
- xdp file chooser
